### PR TITLE
Fix type errors blocking safe:build; convert stray .eslintrc to .prettierrc

### DIFF
--- a/astro-app/.eslintrc
+++ b/astro-app/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "singleQuote": true,
-  "trailingComma": "all",
-  "arrowParens": "avoid",
-  "tabWidth": 2,
-  "printWidth": 120
-}

--- a/astro-app/.prettierrc
+++ b/astro-app/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "plugins": ["prettier-plugin-astro"],
+    "singleQuote": true,
+    "tabWidth": 4
+}

--- a/astro-app/src/components/blocks/mark.astro
+++ b/astro-app/src/components/blocks/mark.astro
@@ -29,7 +29,7 @@ const mark = node as MarkProps['node'];
 {
     mark.markType === 'link' && (
         <a
-            href={(node as unknown as Mark<{ href: string }>).markDef.href}
+            href={(node as unknown as { markDef: { href: string } }).markDef.href}
             class="link link-primary"
             {...attrs}
         >

--- a/astro-app/src/components/math/chemicalEquationBalancer.ts
+++ b/astro-app/src/components/math/chemicalEquationBalancer.ts
@@ -21,11 +21,11 @@ function balance(formulaStr: string): string {
         if (typeof e == 'string') {
             // Simple error message string
             return 'Sintaksės klaida: ' + e;
-        } else if ('start' in e) {
+        } else if (typeof e == 'object' && e !== null && 'start' in e) {
             // Error message object with start and possibly end character indices
-
-            const start: number = e.start;
-            let end: number = 'end' in e ? e.end : e.start;
+            const err = e as { start: number; end?: number; message: string };
+            const start: number = err.start;
+            let end: number = err.end ?? err.start;
             while (
                 end > start &&
                 [' ', '\t'].indexOf(formulaStr.charAt(end - 1)) != -1
@@ -45,7 +45,7 @@ function balance(formulaStr: string): string {
                 );
             } else codeOutput.appendChild(createElem('u', ' '));
 
-            output.innerHTML = `<p>${e.message}</p>`;
+            output.innerHTML = `<p>${err.message}</p>`;
             output.appendChild(codeOutput);
             return output.innerHTML;
         } else {
@@ -68,7 +68,7 @@ function balance(formulaStr: string): string {
 
         return output.innerHTML;
     } catch (e) {
-        return e.toString();
+        return String(e);
     }
 }
 

--- a/astro-app/src/layouts/Layout.astro
+++ b/astro-app/src/layouts/Layout.astro
@@ -3,7 +3,10 @@
 import { ClientRouter } from 'astro:transitions';
 import Navigation from '@/components/Navigation.astro';
 import '@/assets/app.css';
-import Analytics from '@vercel/analytics/astro';
+// @vercel/analytics ships its Astro component behind a @ts-expect-error re-export,
+// so astro check can't see a valid component type; cast to keep safe:build green.
+import VercelAnalytics from '@vercel/analytics/astro';
+const Analytics = VercelAnalytics as unknown as (props: Record<string, never>) => unknown;
 
 interface Props {
     title: string;


### PR DESCRIPTION
## Summary
- Fixes the 7 pre-existing type errors that made `bun run safe:build` fail (while `astro build` alone succeeded). Verified green on this branch: `astro check` + `tsc --noEmit` pass, 118 pages build.
  - `chemicalEquationBalancer.ts` (5 errors): narrow the `unknown` catch value before `'start' in e` / property access; `String(e)` instead of `e.toString()`.
  - `mark.astro` (1): the `Mark<T>` generic was never imported and doesn't resolve; replaced with an inline `{ markDef: { href: string } }` cast.
  - `Layout.astro` (1): `@vercel/analytics/astro` ships its component behind a `@ts-expect-error` re-export in its own dist, so `astro check` rejects `<Analytics />`; cast the import to a component-shaped type.
- Replaces `astro-app/.eslintrc` (which contained Prettier options, not ESLint config — and ESLint 10 flat config never reads `.eslintrc` anyway) with a proper `astro-app/.prettierrc` that loads `prettier-plugin-astro` and matches the actual code style (4-space indent, single quotes — verified: hand-written TS like `sanity.ts` passes `prettier --check` with this config). No mass reformat included; run `bunx prettier --write .` separately if wanted.

## Test plan
- `cd astro-app && bun run safe:build` → passes, 118 pages
- `bunx prettier --check src/utils/sanity.ts` with the new config → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)